### PR TITLE
Webpack loader tokenisation rewrite (#5)

### DIFF
--- a/packages/css-modules-flow-types-cli/src/converter.js
+++ b/packages/css-modules-flow-types-cli/src/converter.js
@@ -17,7 +17,7 @@ export default class Converter {
         .fetch(filePath, '/', undefined, undefined)
         .then(res => {
           if (res) {
-            const content = printFlowDefinition(res);
+            const content = printFlowDefinition(Object.keys(res));
             resolve(content);
           } else {
             reject(res);

--- a/packages/css-modules-flow-types-loader/__test__/index.test.js
+++ b/packages/css-modules-flow-types-loader/__test__/index.test.js
@@ -21,6 +21,13 @@ exports.locals = {
 };
 `);
 
+const STYLE_LOADER_OUTPUT_WITH_JS = getStyleLoaderOutput(`
+exports.locals = {
+"foo": "bar" + require("-!css-loader!styles/baz.scss").locals["xyz"] + "",
+"foo2": "bar" + new String('lorem lipsum') + ""
+};
+`);
+
 const EMPTY_STYLE_LOADER_OUTPUT = getStyleLoaderOutput();
 
 const BANNER = `// @flow
@@ -79,5 +86,18 @@ declare module.exports: {|
       STYLE_LOADER_OUTPUT
     );
     expect(returnedContent).toBe(STYLE_LOADER_OUTPUT);
+  });
+
+  it('does not fail on arbitrary javascript in the ICSS value', () => {
+    loader.call({ resourcePath: 'test.css' }, STYLE_LOADER_OUTPUT_WITH_JS);
+
+    expect(fs.writeFile.mock.calls[0][1]).toBe(
+      `${BANNER}
+declare module.exports: {|
+  +'foo': string;
+  +'foo2': string;
+|};
+`
+    );
   });
 });

--- a/packages/css-modules-flow-types-loader/index.js
+++ b/packages/css-modules-flow-types-loader/index.js
@@ -4,11 +4,19 @@ import fs from 'fs';
 import printFlowDefinition from 'css-modules-flow-types-printer';
 
 function getTokens(content) {
-  const cssTokens = content.replace(/\s/g, '').match('exports.locals=(.*);');
-  if (cssTokens) {
-    return JSON.parse(cssTokens[1]);
-  }
-  return {};
+  const tokens = [];
+
+  // Only `locals` export is desired
+  const locals = content.match(/exports\.locals = ([\s\S]*);/);
+
+  if (!locals) return tokens;
+  let match;
+
+  // RegExp.exec is state-full, so we need to initialize new one for each run
+  const re = /"(.*?)":.*\n/g;
+  while ((match = re.exec(locals[1])) !== null) tokens.push(match[1]);
+
+  return tokens;
 }
 
 module.exports = function cssModulesFlowTypesLoader(content) {

--- a/packages/css-modules-flow-types-printer/index.js
+++ b/packages/css-modules-flow-types-printer/index.js
@@ -2,8 +2,8 @@
 
 import os from 'os';
 
-export default function printFlowDefinition(tokens, indent = '  ') {
-  const props = Object.keys(tokens)
+export default function printFlowDefinition(tokensArray, indent = '  ') {
+  const props = tokensArray
     .sort()
     .map(key => `${indent}+'${key}': string;`)
     .join(os.EOL);


### PR DESCRIPTION
This is a (not yet fully tested) attempt at fixing #5.

All current tests pass, but I didn't have a mental capacity to correctly think through failing test case for the issue at hand.

Running it through my code-base does however produce `.flow` files correctly (giving it just a quick glance and testing that flow indeed produces errors for undefined className).

That's all from for today (https://imgs.xkcd.com/comics/perl_problems.png). 

Tomorrow I can take a look at that test, but if you'd feel an endless need to write it yourself I wouldn't be all that sad :-)