### PR TITLE
Silent mode

### DIFF
--- a/packages/css-modules-flow-types-cli/src/cli.js
+++ b/packages/css-modules-flow-types-cli/src/cli.js
@@ -23,15 +23,17 @@ path    directory to search for CSS Modules (or concrete files to convert)
 Options
   --watch, -w       Run in watch mode
   --extension, -e   File extension (defaults to "css")
+  --silent, -s      Silences all output except errors
     `,
   },
   {
-    boolean: ['watch'],
+    boolean: ['watch', 'silent'],
     string: ['_'],
     alias: {
       e: 'extension',
       h: 'help',
       w: 'watch',
+      s: 'silent',
     },
   }
 );
@@ -56,7 +58,7 @@ function detectDanlingFlowFiles(filesPattern, cssFiles) {
 }
 
 const main = () => {
-  const { watch } = cli.flags;
+  const { watch, silent } = cli.flags;
 
   if (!cli.input || cli.input.length === 0) {
     return cli.showHelp();
@@ -80,7 +82,9 @@ const main = () => {
         return writeFile(outputFilePath, content);
       })
       .then(outputFilePath => {
-        console.log('Wrote ' + chalk.green(outputFilePath));
+        if (!silent) {
+          console.log('Wrote ' + chalk.green(outputFilePath));
+        }
       })
       .catch(reason => console.error(chalk.red('[Error] ' + reason)));
   }


### PR DESCRIPTION
Related: #4 

Adds `--silent` flag as an option to silence "Wrote ..." logs.
Off by default

![flow-modules-silent](https://user-images.githubusercontent.com/22854722/31583802-ccea1aa6-b1a1-11e7-8323-be07a82b53a9.gif)
