### PR TITLE
Do not rewrite files when content did not change

### DIFF
--- a/packages/css-modules-flow-types-loader/__test__/index.test.js
+++ b/packages/css-modules-flow-types-loader/__test__/index.test.js
@@ -74,6 +74,50 @@ declare module.exports: {|
     );
   });
 
+  it('does not emit a css.flow file if the file exists and has the same contents', () => {
+    fs.existsSync.mockImplementationOnce(
+      filePath => filePath === 'test.css.flow'
+    );
+
+    loader.call(
+      {
+        resourcePath: 'test.css',
+      },
+      STYLE_LOADER_OUTPUT
+    );
+
+    expect(fs.writeFile.mock.calls.length).toBe(0);
+  });
+
+  it('emits a css.flow file if the file exists and has the different contents', () => {
+    fs.existsSync.mockImplementationOnce(
+      filePath => filePath === 'test.css.flow'
+    );
+
+    fs.readFile.mockImplementationOnce((filePath, opts, cb) => {
+      if (filePath === 'test.css.flow') {
+        cb(null, 'Other content');
+      }
+    });
+    loader.call(
+      {
+        resourcePath: 'test.css',
+      },
+      STYLE_LOADER_OUTPUT
+    );
+
+    expect(fs.writeFile.mock.calls.length).toBe(1);
+    expect(fs.writeFile.mock.calls[0][0]).toBe('test.css.flow');
+
+    expect(fs.writeFile.mock.calls[0][1]).toBe(
+      `${HEADER}
+declare module.exports: {|
+  +'btn': string;
+|};
+`
+    );
+  });
+
   it('returns same content as given', () => {
     const emitFile = jest.fn();
     const returnedContent = loader.call(

--- a/packages/css-modules-flow-types-loader/index.js
+++ b/packages/css-modules-flow-types-loader/index.js
@@ -25,7 +25,20 @@ module.exports = function cssModulesFlowTypesLoader(content) {
   // NOTE: We cannot use .emitFile as people might use this with devServer
   // (e.g. in memory storage).
   const outputPath = this.resourcePath + '.flow';
-  fs.writeFile(outputPath, printFlowDefinition(tokens), {}, function() {});
+  const newContent = printFlowDefinition(tokens);
+  if (fs.existsSync(outputPath)) {
+    fs.readFile(outputPath, 'utf8', function(err, currentContent) {
+      if (err) {
+        throw err;
+      }
+
+      if (currentContent !== newContent) {
+        fs.writeFile(outputPath, newContent, {}, function() {});
+      }
+    });
+  } else {
+    fs.writeFile(outputPath, newContent, {}, function() {});
+  }
 
   return content;
 };


### PR DESCRIPTION
First of all thanks for all the great work on this package,👏  it has been super useful!

I know that there is no open issue for this, so feel free to close this PR if this does not go with the direction of the project.

### TL;DR

Don't write a new version of the `.css.flow` file if the contents did not change.

### The problem
Every time that a file is changed our git repo gets dirty, making it hard to do 

```
❯ git status
On branch my-banrch
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)

	modified:   src/components/Component1/styles.css.flow
	modified:   src/components/Component2/styles.css.flow
```

```
❯ git diff
diff --git a/src/components/Component1/styles.css.flow b/src/components/Component1/styles.css.flow
index 9c8e505..e69de29 100644
--- a/src/components/Component1/styles.css.flow
+++ b/src/components/Component1/styles.css.flow
@@ -1,9 +0,0 @@
-// @flow
-/* This file is automatically generated by css-modules-flow-types */
-declare module.exports: {|
-  +'class1': string;
-  +'class2': string;
-  +'class3': string;
-|};

diff --git a/src/components/Component2/styles.css.flow b/src/components/Component2/styles.css.flow
index 9c8e505..e69de29 100644
--- a/src/components/Component2/styles.css.flow
+++ b/src/components/Component2/styles.css.flow
@@ -1,9 +0,0 @@
-// @flow
-/* This file is automatically generated by css-modules-flow-types */
-declare module.exports: {|
-  +'class1': string;
-  +'class2': string;
-  +'class3': string;
-|};
```