### PR TITLE
Support css loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "css-modules-flow-types",
   "private": true,
   "scripts": {
     "build": "lerna run build",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,4 @@
 {
-  "name": "css-modules-flow-types",
   "version": "0.3.1",
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "css-modules-flow-types",
+  "version": "0.3.1",
   "private": true,
   "scripts": {
     "build": "lerna run build",

--- a/packages/css-modules-flow-types-loader/__test__/index.test.js
+++ b/packages/css-modules-flow-types-loader/__test__/index.test.js
@@ -30,8 +30,6 @@ exports.locals = {
 `);
 const EMPTY_LOADER_OUTPUT = getStyleLoaderOutput();
 
-const EMPTY_STYLE_LOADER_OUTPUT = getStyleLoaderOutput();
-
 describe('webpack loader (using style-loader)', () => {
   beforeEach(() => {
     fs.writeFile.mockReset();
@@ -109,7 +107,7 @@ describe('webpack loader (using css-loader)', () => {
     expect(fs.writeFile.mock.calls[0][0]).toBe('test.css.flow');
 
     expect(fs.writeFile.mock.calls[0][1]).toBe(
-      `${BANNER}
+      `${HEADER}
 declare module.exports: {|
   +'btn': string;
 |};
@@ -127,7 +125,7 @@ declare module.exports: {|
 
     expect(fs.writeFile.mock.calls.length).toBe(1);
     expect(fs.writeFile.mock.calls[0][1]).toBe(
-      `${BANNER}
+      `${HEADER}
 declare module.exports: {|
 
 |};

--- a/packages/css-modules-flow-types-loader/index.js
+++ b/packages/css-modules-flow-types-loader/index.js
@@ -2,6 +2,7 @@
 
 import fs from 'fs';
 import printFlowDefinition from 'css-modules-flow-types-printer';
+import Tokenizer from 'css-selector-tokenizer';
 
 function getTokens(content) {
   const tokens = [];
@@ -19,13 +20,35 @@ function getTokens(content) {
   return tokens;
 }
 
-module.exports = function cssModulesFlowTypesLoader(content) {
-  const tokens = getTokens(content);
+const getAllClassNames = (tokens) => {
+  const names = tokens.nodes.reduce((acc, node) => {
+    if(node.type == 'selector') {
+      const names = getAllClassNames(node)
+            .filter(n => n.type == 'class')
+      return acc.concat(names)
+    }
+    else if(node.type == 'class'){
+      acc.push(node)
+    }
+    return acc
+  },[])
+  return names
+}
 
+const toNamesObj = (nodes) => {
+  const namesObj = {}
+  nodes.forEach(n => namesObj[n.name] = '')
+  return namesObj
+}
+
+module.exports = function cssModulesFlowTypesLoader(content) {
   // NOTE: We cannot use .emitFile as people might use this with devServer
   // (e.g. in memory storage).
   const outputPath = this.resourcePath + '.flow';
-  fs.writeFile(outputPath, printFlowDefinition(tokens), {}, function() {});
+  const cssContents = fs.readFileSync(this.resourcePath, 'utf8')
+  const nodes = getAllClassNames(Tokenizer.parse(cssContents))
+  const output = printFlowDefinition(toNamesObj(nodes)) 
+  fs.writeFile(outputPath, output, {}, function() {});
 
   return content;
 };

--- a/packages/css-modules-flow-types-loader/index.js
+++ b/packages/css-modules-flow-types-loader/index.js
@@ -33,21 +33,12 @@ const getAllClassNames = tokens => {
   return names;
 };
 
-const toNamesObj = nodes => {
-  const namesObj = {};
-  nodes.forEach(n => (namesObj[n.name] = ''));
-  return namesObj;
-};
-
 const getCssModuleImport = (resourcePath, content) => {
   if (fs.existsSync(resourcePath)) {
-    console.log('file exists');
     const cssContents = fs.readFileSync(resourcePath, 'utf8');
-    console.log('css contents', cssContents);
     const nodes = getAllClassNames(Tokenizer.parse(cssContents));
-    return toNamesObj(nodes);
+    return nodes.map(n => n.name);
   } else {
-    console.log('file missing', resourcePath);
     return getTokens(content);
   }
 };

--- a/packages/css-modules-flow-types-loader/package.json
+++ b/packages/css-modules-flow-types-loader/package.json
@@ -13,7 +13,8 @@
     "node": ">=4"
   },
   "scripts": {
-    "build": "babel *.js -d dist --ignore *.test.js"
+    "build": "babel *.js -d dist --ignore *.test.js",
+    "prepublish": "cd ../../ && npm run prepublish"
   },
   "files": [
     "dist"

--- a/packages/css-modules-flow-types-loader/package.json
+++ b/packages/css-modules-flow-types-loader/package.json
@@ -13,8 +13,7 @@
     "node": ">=4"
   },
   "scripts": {
-    "build": "babel *.js -d dist --ignore *.test.js",
-    "prepublish": "cd ../../ && npm run prepublish"
+    "build": "babel *.js -d dist --ignore *.test.js"
   },
   "files": [
     "dist"
@@ -27,6 +26,10 @@
     "webpack loader"
   ],
   "dependencies": {
-    "css-modules-flow-types-printer": "^1.0.0"
+    "css-modules-flow-types-printer": "^1.0.0",
+    "css-selector-tokenizer": "^0.7.0"
+  },
+  "devDependencies": {
+    "babel-cli": "^6.26.0"
   }
 }


### PR DESCRIPTION
This adds support for `css-loader`, which does _not_ pass data via the `content` passed to the loader function. Instead we have to check the file at `resourcePath`.

At the time of consuming this library, our team didn't have the cycles to put together a proper pull request and see that merged. We instead worked out of a fork. Maybe this is a problem with my experience with `lerna` but in order to refer to the repo via a `git+ssh` URL for our fork, I had to make some adjustments to the `package.json`. Are those fine leaving in in case we need to fork again (or someone else does)?

Our internal work repo has been using this for a while new to help us achieve 100% flow coverage, and of course provide strong typing for all of our UI components. Thanks for putting this together!