### PR TITLE
add css-loader example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ declare module.exports: {|
 
 ## Usage (Webpack loader)
 
+### style-loader
 The `css-modules-flow-types-loader` need to be added right after after `style-loader`:
 
 ```sh
@@ -61,6 +62,27 @@ $ yarn install -D css-modules-flow-types-loader
 }
 ```
 
+### css-loader
+
+For `css-loader`, `css-modules-flow-types-loader` needs to come _before_
+`css-loader`.
+
+```javascript
+{
+  test: /\.css$/,  // or the file format you are using for your CSS Modules
+  use: [
+    ExtractTextPlugin.extract({
+      use: [
+        'css-modules-flow-types-loader',
+        {
+          loader: 'css-loader',
+          options: {}, // Any options for css-loader
+        }
+      ]
+    })
+  ]
+}
+```
 
 ## Usage (CLI)
 


### PR DESCRIPTION
This adds an example of how to use `css-modules-flow-types` with `css-loader`. This is a desirable configuration when you want your webpack output to maintain a separate `.css` file, whereas `style-loader` embeds all of the CSS into a `style` tag on the page.

I lifted this example from a working Webpack config and trimmed out any project-specific configuration.